### PR TITLE
Add trim attribute to StringField class to remove any extra spaces

### DIFF
--- a/rip/schema/string_field.py
+++ b/rip/schema/string_field.py
@@ -13,10 +13,11 @@ class StringField(BaseField):
             self, max_length=256, required=False,
             field_type=FieldTypes.DEFAULT, nullable=True,
             entity_attribute=None, show_in_list=True,
-            blank=True):
+            blank=True, trim=False):
 
         self.max_length = max_length
         self.blank = blank
+        self.trim = trim
         super(StringField, self).__init__(
             required=required, field_type=field_type, nullable=nullable,
             entity_attribute=entity_attribute, show_in_list=show_in_list)
@@ -44,3 +45,9 @@ class StringField(BaseField):
                                     reason=u'Maxlength of {} exceeded' \
                                     .format(self.max_length))
         return ValidationResult(is_success=True)
+
+    def clean(self, request, value):
+        value = super(StringField, self).clean(request, value)
+        return value.strip() if self.trim else value
+    
+

--- a/rip/schema/string_field.py
+++ b/rip/schema/string_field.py
@@ -48,6 +48,12 @@ class StringField(BaseField):
 
     def clean(self, request, value):
         value = super(StringField, self).clean(request, value)
-        return value.strip() if self.trim else value
-    
+        if self.trim is True:
+            return value.strip()
+        elif self.trim:
+            return value.strip(self.trim)
+        else:
+            return value
+
+
 

--- a/tests/unit_tests/schema/test_string_field.py
+++ b/tests/unit_tests/schema/test_string_field.py
@@ -85,8 +85,19 @@ class TestCharField(TestCase):
         assert result == ' asd '
 
     def test_should_strip_value(self):
-        string_filed = StringField(trim=True)
+        string_field = StringField(trim=True)
 
-        result = string_filed.clean(request=None, value=' asd ')
+        result = string_field.clean(request=None, value=' asd ')
 
         assert result == 'asd'
+
+    def test_should_strip_value_for_given_characters(self):
+        string_field = StringField(trim=' ')
+
+        result = string_field.clean(request=None, value=' asd ')
+
+        assert result == 'asd'
+
+
+
+

--- a/tests/unit_tests/schema/test_string_field.py
+++ b/tests/unit_tests/schema/test_string_field.py
@@ -76,3 +76,17 @@ class TestCharField(TestCase):
         result = string_field.validate(request=None, value="asd")
 
         assert result.is_success is True
+
+    def test_should_not_strip_value(self):
+        string_field = StringField()
+
+        result = string_field.clean(request=None, value=" asd ")
+
+        assert result == ' asd '
+
+    def test_should_strip_value(self):
+        string_filed = StringField(trim=True)
+
+        result = string_filed.clean(request=None, value=' asd ')
+
+        assert result == 'asd'


### PR DESCRIPTION
Added  a boolean attribute 'trim'  attribute to StringField class
By default 'trim' attribute is set to False
Defined override method 'clean'
Based on the value of 'trim' clean method is striping the value

Covered unit test cases for the clean method