### PR TITLE
Issue: Non-required fields were not serializing properly.

### DIFF
--- a/rip/generic_steps/default_schema_serializer.py
+++ b/rip/generic_steps/default_schema_serializer.py
@@ -52,8 +52,14 @@ class DefaultEntitySerializer(object):
                 serialized_value = field_override(request, entity)
             else:
                 entity_attribute = field.entity_attribute or field_name
-                serialized_value = attribute_getter.get_attribute(
-                    entity, entity_attribute)
+
+                try:
+                    serialized_value = attribute_getter.get_attribute(
+                        entity, entity_attribute)
+                except AttributeError as ex:
+                    if field.required:
+                        raise ex
+                    continue
 
             serialized[field_name] = field.serialize(request, serialized_value)
         return serialized

--- a/tests/unit_tests/generic_steps/test_default_schema_serializer.py
+++ b/tests/unit_tests/generic_steps/test_default_schema_serializer.py
@@ -15,6 +15,7 @@ __all__ = ["TestSerializeSchemaToResponse"]
 class TestSerializeSchemaToResponse(unittest.TestCase):
     def setUp(self):
         class TestSchema(ApiSchema):
+            id = StringField(required=True)
             name = StringField(max_length=32)
             is_active = BooleanField()
 
@@ -26,26 +27,40 @@ class TestSerializeSchemaToResponse(unittest.TestCase):
 
     def test_should_serialize_to_response(self):
         request = Request(user=None, request_params=None)
-        request.context_params['entity'] = dict(name='asdf', is_active=True)
+        request.context_params['entity'] = dict(id='aaaa', name='asdf', is_active=True)
 
         request = self.serializer.serialize_detail(request)
         self.assertEqual(request.context_params['serialized_data'],
-                         dict(name='asdf', is_active=True))
+                         dict(id='aaaa', name='asdf', is_active=True))
 
+    def test_should_not_throw_error_on_missing_non_required_fields(self):
+        request = Request(user=None, request_params=None)
+        request.context_params['entity'] = dict(id='aaaa', is_active=True)
+
+        request = self.serializer.serialize_detail(request)
+        self.assertEqual(request.context_params['serialized_data'],
+                         dict(id='aaaa', is_active=True))
+
+    def test_should_throw_error_on_missing_required_fields(self):
+        request = Request(user=None, request_params=None)
+        request.context_params['entity'] = dict(name='asdf', is_active=True)
+
+        self.assertRaises(AttributeError,
+                          self.serializer.serialize_detail, request)
 
     def test_should_serialize_list_to_response(self):
         request = Request(user=None, request_params=None, context_params={})
         request.context_params['total_count'] = 10
         request.context_params['request_filters'] = {'offset': 0, 'limit': 20}
         request.context_params['entities'] = \
-            [dict(name='asdf', is_active=True),
-             dict(name='asdf', is_active=False)]
+            [dict(id='aaaa', name='asdf', is_active=True),
+             dict(id='bbbb', name='asdf', is_active=False)]
 
         request = self.serializer.serialize_list(request)
 
         data = request.context_params['serialized_data']['objects']
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0],
-                         dict(name='asdf', is_active=True))
+                         dict(id='aaaa', name='asdf', is_active=True))
         self.assertEqual(data[1],
-                         dict(name='asdf', is_active=False))
+                         dict(id='bbbb', name='asdf', is_active=False))


### PR DESCRIPTION
Explanation:
Suppose an entity has a non required field.
When the default schema serializer tries to serialize an entity from a dictionary, it expects the dictionary to have a key for the non required field.
This is not the expected behavior.
The entity should get serialized even if the dictionary is missing the keys for non required fields.
It should throw an error only if the field is a required field.

Solution:
Check whether a field is required, before throwing exceptions if the key is missing.

Code changes.
Catch exceptions thrown by the attribute getter, and bubble them up only if the field is required.
Suppress errors if field is not a required field.
rip/generic_steps/default_schema_serializer.py

Unit tests.
tests/unit_tests/generic_steps/test_default_schema_serializer.py