### PR TITLE
Create view resource

### DIFF
--- a/rip/default_view_actions.py
+++ b/rip/default_view_actions.py
@@ -1,0 +1,8 @@
+class DefaultViewActions(object):
+    def read(self, request):
+        view_data = self.view(request)
+        request.context_params['entity'] = view_data
+        return request
+
+    def view(self, request):
+        raise NotImplementedError('You need to override get on actions')

--- a/rip/django_adapter/action_resolver.py
+++ b/rip/django_adapter/action_resolver.py
@@ -1,3 +1,5 @@
+from rip.view.view_resource import ViewResource
+
 method_to_action_mapping = {
     'GET': 'read',
     'POST': 'create',
@@ -31,12 +33,16 @@ def resolve_action(http_request, url, api):
     try:
         resource = api.resolve_resource(url)
         endpoint = determine_end_point(http_request, url)
-        if endpoint == 'aggregates':
-            resource_action = 'get_aggregates'
+        if isinstance(resource, ViewResource):
+            action = resource.read
         else:
-            resource_action = "%s_%s" % (
-                method_to_action_mapping.get(http_request.method), endpoint)
-        action = getattr(resource, resource_action)
+            if endpoint == 'aggregates':
+                resource_action = 'get_aggregates'
+            else:
+                resource_action = "%s_%s" % (
+                    method_to_action_mapping.get(http_request.method), endpoint)
+            action = getattr(resource, resource_action)
+
         return action
     except AttributeError:
         return None

--- a/rip/view/decorators.py
+++ b/rip/view/decorators.py
@@ -1,0 +1,16 @@
+from rip import error_types
+from rip.response import Response
+from rip.view.view_actions import ViewActions
+
+
+def validate_view_action(func):
+    def wrapper(self, request):
+        action = ViewActions.resolve_action(func.__name__)
+        request.context_params['view_action'] = action
+
+        if not self.is_action_allowed(action):
+            return Response(
+                is_success=False, reason=error_types.MethodNotAllowed)
+        return func(self, request=request)
+
+    return wrapper

--- a/rip/view/default_view_authorization.py
+++ b/rip/view/default_view_authorization.py
@@ -1,0 +1,3 @@
+class DefaultViewAuthorization(object):
+    def authorize_read(self, request):
+        return request

--- a/rip/view/view_actions.py
+++ b/rip/view/view_actions.py
@@ -1,0 +1,26 @@
+class ViewActions(object):
+    READ = 'read'
+
+    _reverse_dictionary = None
+
+    @classmethod
+    def _get_reverse_dictionary(cls):
+        if not cls._reverse_dictionary:
+            cls._reverse_dictionary = _build_reverse_dictionary(cls)
+        return cls._reverse_dictionary
+
+    @classmethod
+    def resolve_action(cls, name):
+        cls_attr = cls._get_reverse_dictionary()[name]
+        return getattr(cls, cls_attr)
+
+    @classmethod
+    def get_all_actions(cls):
+        return (
+            cls.READ,
+        )
+
+
+def _build_reverse_dictionary(cls):
+    return {v: k for k, v in cls.__dict__.items() if
+            k != '_reverse_dictionary'}

--- a/rip/view/view_pipeline_factory.py
+++ b/rip/view/view_pipeline_factory.py
@@ -1,0 +1,24 @@
+from rip import pipeline_composer
+from rip.crud.crud_actions import CrudActions
+
+
+def read_pipeline(configuration):
+    view_actions = configuration['view_actions']
+    authentication = configuration['authentication']
+    authorization = configuration['authorization']
+    serializer = configuration['serializer']
+    post_action_hooks = configuration['post_action_hooks']
+    response_converter = configuration['response_converter']
+
+    pipeline = pipeline_composer.compose_pipeline(
+        name=CrudActions.READ_LIST,
+        pipeline=[
+            authentication.authenticate,
+            authorization.authorize_read,
+            view_actions.read,
+            serializer.serialize_detail,
+            post_action_hooks.read_detail_hook,
+            response_converter.convert_serialized_data_to_response
+        ])
+
+    return pipeline

--- a/rip/view/view_resource.py
+++ b/rip/view/view_resource.py
@@ -1,0 +1,123 @@
+from rip.default_view_actions import DefaultViewActions
+from rip.generic_steps.default_authentication import \
+    DefaultAuthentication
+from rip.generic_steps.default_post_action_hooks import \
+    DefaultPostActionHooks
+from rip.generic_steps.default_response_converter import \
+    DefaultResponseConverter
+from rip.generic_steps.default_schema_serializer import \
+    DefaultEntitySerializer
+from rip.generic_steps.default_schema_validation import \
+    DefaultSchemaValidation
+from rip.view import view_pipeline_factory
+from rip.view.decorators import validate_view_action
+from rip.view.default_view_authorization import DefaultViewAuthorization
+from rip.view.view_actions import ViewActions
+
+
+class ViewResource(object):
+    """
+    Defines a View Resource which like a plain old django view that returns a json.
+    Additionally get options to override authentication, authorization
+
+    Usually you don't have to override methods because steps can be overridden
+    in the configuration attributes
+
+    An example:
+    class Tweet(ViewResource):
+    schema_cls = TweetSchema
+    allowed_actions= [ViewActions.read] # list of allowed actions
+    view_actions_cls = TweetEntityActions # A mandatory hook class
+                                            # that has methods for actions on
+                                            # for the actual view logic
+
+    serializer_cls = TweetEntitySerializer # A hook class
+                                           # for serializing entity to json
+
+    authentication_cls = TweetAuthentication # A hook class that authenticates
+                                             # a request.
+                                             # Default: it checks
+                                             # if a valid user is present on the
+                                             # request
+
+    authorization_cls = TweetAuthorization # A hook class
+                                           # that controls access to entities
+                                           # Default: there is no authorization
+    """
+    schema_cls = None
+    allowed_actions = [ViewActions.READ]
+    filter_by_fields = {}
+
+    authentication_cls = DefaultAuthentication
+    authorization_cls = DefaultViewAuthorization
+    schema_validation_cls = DefaultSchemaValidation
+    view_actions_cls = DefaultViewActions
+    post_action_hooks_cls = DefaultPostActionHooks
+    response_converter_cls = DefaultResponseConverter
+    serializer_cls = DefaultEntitySerializer
+
+    def _setup_configuration(self):
+        """
+        All steps are accepted as classes. Instantiate them with the right
+        configuration and set them in a local property.
+        """
+        self.configuration = dict(
+            schema_cls=self.schema_cls,
+            allowed_actions=self.allowed_actions,
+            filter_by_fields=self.filter_by_fields)
+
+        authentication = self.authentication_cls(schema_cls=self.schema_cls)
+        authorization = self.authorization_cls()
+        schema_validation = self.schema_validation_cls(
+            schema_cls=self.schema_cls)
+        view_actions = self.view_actions_cls()
+        post_action_hooks = self.post_action_hooks_cls(
+            schema_cls=self.schema_cls)
+        response_converter = self.response_converter_cls(
+            schema_cls=self.schema_cls)
+        serializer = self.serializer_cls(schema_cls=self.schema_cls)
+
+        self.configuration.update(dict(
+            authentication=authentication,
+            authorization=authorization,
+            schema_validation=schema_validation,
+            view_actions=view_actions,
+            post_action_hooks=post_action_hooks,
+            response_converter=response_converter,
+            serializer=serializer))
+
+    def __new__(cls, *args, **kwargs):
+        if cls.schema_cls is None:
+            raise TypeError('Missing configuration property `schema_cls` \
+                             on Resource `{resource_name}`'
+                            .format(resource_name=cls.__name__))
+        obj = super(ViewResource, cls).__new__(cls, *args, **kwargs)
+        return obj
+
+    def __init__(self):
+        super(ViewResource, self).__init__()
+        self._setup_configuration()
+
+    def is_action_allowed(self, action_name):
+        """
+        Returns if a particular action is allowed on the resource
+        as set in the allowed_actions attribute
+
+        :param action_name:string
+        :values as defined in ViewActions
+        :return: bool
+        """
+        if action_name not in self.allowed_actions:
+            return False
+        return True
+
+    @validate_view_action
+    def read(self, request):
+        """
+        Implements HTTP GET
+        :param request: rip.Request
+        :return: rip.Response
+        """
+        pipeline = view_pipeline_factory.read_pipeline(
+            configuration=self.configuration)
+        return pipeline(request=request)

--- a/tests/integration_tests/test_crud_resource_end_to_end.py
+++ b/tests/integration_tests/test_crud_resource_end_to_end.py
@@ -1,0 +1,73 @@
+import json
+import os
+import unittest
+
+from hamcrest.core.assert_that import assert_that
+from hamcrest.core.core.isequal import equal_to
+from mock import MagicMock
+
+from rip.api import Api
+from rip.api_schema import ApiSchema
+from rip.crud.crud_resource import CrudResource
+from rip.django_adapter.django_http_handler import create_http_handler
+from rip.generic_steps.default_authentication import DefaultAuthentication
+from rip.generic_steps.default_authorization import DefaultAuthorization
+from rip.generic_steps.default_entity_actions import DefaultEntityActions
+from rip.schema.string_field import StringField
+
+
+class DummySchema(ApiSchema):
+    name = StringField(required=True)
+
+    class Meta:
+        schema_name = 'dummy'
+
+
+class DummyEntityActions(DefaultEntityActions):
+    def get_entity_list(self, request, **kwargs):
+        return [{
+            'name': 'dummy'
+        }]
+
+    def get_entity_list_total_count(self, request, **kwargs):
+        return 1
+
+
+class DummyViewAuthorization(DefaultAuthorization):
+    pass
+
+
+class DummyAuthentication(DefaultAuthentication):
+    pass
+
+
+class DummyViewResource(CrudResource):
+    schema_cls = DummySchema
+    entity_actions_cls = DummyEntityActions
+    authorization_cls = DummyViewAuthorization
+    authentication_cls = DummyAuthentication
+
+
+class DummyUser(object):
+    def is_anonymous(self):
+        return False
+
+
+class TestApi(unittest.TestCase):
+    def setUp(self):
+        os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+        self.api = Api(name='api', version='v1')
+        self.api.register_resource('dummy', DummyViewResource())
+        self.handler = create_http_handler(self.api)
+
+    def test_crud_resource_get_list(self):
+        url = 'dummy'
+        user = DummyUser()
+
+        http_request = MagicMock(user=user, method='GET')
+
+        response = self.handler(http_request, url)
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(json.loads(response.content), equal_to(
+            {"objects": [{"name": "dummy"}], "meta": {"total": 1, "limit": 20, "offset": 0}}))

--- a/tests/integration_tests/test_view_resource.py
+++ b/tests/integration_tests/test_view_resource.py
@@ -1,0 +1,105 @@
+import unittest
+
+from hamcrest.core import assert_that
+from hamcrest.core.core.isequal import equal_to
+from mock import patch
+
+from rip import error_types
+from rip.api_schema import ApiSchema
+from rip.default_view_actions import DefaultViewActions
+from rip.generic_steps.default_authentication import DefaultAuthentication
+from rip.response import Response
+from rip.schema.string_field import StringField
+from rip.view.default_view_authorization import DefaultViewAuthorization
+from rip.view.view_resource import ViewResource
+from tests import request_factory
+
+
+class DummySchema(ApiSchema):
+    name = StringField(required=True)
+
+
+class DummyViewActions(DefaultViewActions):
+    def view(self, request):
+        return {
+            'name': 'dummy'
+        }
+
+
+class DummyAuthorization(DefaultViewAuthorization):
+    pass
+
+
+class DummyAuthentication(DefaultAuthentication):
+    pass
+
+
+class DummyResource(ViewResource):
+    schema_cls = DummySchema
+    view_actions_cls = DummyViewActions
+    authorization_cls = DummyAuthorization
+    authentication_cls = DummyAuthentication
+
+
+def patch_allowed_actions(resource_cls, value):
+    def outer_wrapper(func):
+        def wrapper(*args, **kwargs):
+            old_allowed_actions = resource_cls.allowed_actions
+            resource_cls.allowed_actions = value
+            try:
+                return func(*args, **kwargs)
+            finally:
+                resource_cls.allowed_actions = old_allowed_actions
+
+        return wrapper
+
+    return outer_wrapper
+
+
+class TestViewResourceActions(unittest.TestCase):
+    def test_view_returns_value(self):
+        resource = DummyResource()
+
+        response = resource.read(request_factory.get_request(user=object()))
+
+        assert_that(response.data, equal_to({'name': 'dummy'}))
+
+    @patch.object(DummyViewActions, 'view')
+    def test_when_view_returns_bad_schema(self, mocked_view):
+        mocked_view.return_value = {'foo': 'bar'}
+
+        resource = DummyResource()
+
+        with(self.assertRaises(AttributeError)):
+            resource.read(request_factory.get_request(user=object()))
+
+    @patch.object(DummyAuthorization, 'authorize_read')
+    def test_when_authorization_fails(self, mocked_authorize_read):
+        mocked_authorize_read.return_value = Response(is_success=False,
+                                                      reason=error_types.ActionForbidden,
+                                                      data={'foo': 'bar'})
+
+        response = DummyResource().read(request=request_factory.get_request(user=object()))
+
+        assert_that(response.is_success, equal_to(False))
+        assert_that(response.reason, equal_to(error_types.ActionForbidden))
+        assert_that(response.data, equal_to({'foo': 'bar'}))
+
+    @patch.object(DummyAuthentication, 'authenticate')
+    def test_when_authentication_fails(self, mocked_authenticate):
+        mocked_authenticate.return_value = Response(is_success=False,
+                                                    reason=error_types.AuthenticationFailed,
+                                                    data={'foo': 'bar'})
+
+        response = DummyResource().read(request=request_factory.get_request(user=object()))
+
+        assert_that(response.is_success, equal_to(False))
+        assert_that(response.reason, equal_to(error_types.AuthenticationFailed))
+        assert_that(response.data, equal_to({'foo': 'bar'}))
+
+    @patch_allowed_actions(DummyResource, [])
+    def test_when_method_not_allowed(self):
+        response = DummyResource().read(request=request_factory.get_request(user=object()))
+
+        assert_that(response.is_success, equal_to(False))
+        assert_that(response.reason, equal_to(error_types.MethodNotAllowed))

--- a/tests/integration_tests/test_view_resource_end_to_end.py
+++ b/tests/integration_tests/test_view_resource_end_to_end.py
@@ -1,0 +1,69 @@
+import json
+import os
+import unittest
+
+from hamcrest.core.assert_that import assert_that
+from hamcrest.core.core.isequal import equal_to
+from mock import MagicMock
+
+from rip.api import Api
+from rip.api_schema import ApiSchema
+from rip.default_view_actions import DefaultViewActions
+from rip.django_adapter.django_http_handler import create_http_handler
+from rip.generic_steps.default_authentication import DefaultAuthentication
+from rip.schema.string_field import StringField
+from rip.view.default_view_authorization import DefaultViewAuthorization
+from rip.view.view_resource import ViewResource
+
+
+class DummySchema(ApiSchema):
+    name = StringField(required=True)
+
+    class Meta:
+        schema_name = 'dummy'
+
+
+class DummyViewActions(DefaultViewActions):
+    def view(self, request):
+        return {
+            'name': 'dummy'
+        }
+
+
+class DummyViewAuthorization(DefaultViewAuthorization):
+    pass
+
+
+class DummyAuthentication(DefaultAuthentication):
+    pass
+
+
+class DummyViewResource(ViewResource):
+    schema_cls = DummySchema
+    view_actions_cls = DummyViewActions
+    authorization_cls = DummyViewAuthorization
+    authentication_cls = DummyAuthentication
+
+
+class DummyUser(object):
+    def is_anonymous(self):
+        return False
+
+
+class TestApi(unittest.TestCase):
+    def setUp(self):
+        os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
+        self.api = Api(name='api', version='v1')
+        self.api.register_resource('dummy', DummyViewResource())
+        self.handler = create_http_handler(self.api)
+
+    def test_view_resource(self):
+        url = 'dummy'
+        user = DummyUser()
+
+        http_request = MagicMock(user=user, method='GET')
+
+        response = self.handler(http_request, url)
+
+        assert_that(response.status_code, equal_to(200))
+        assert_that(json.loads(response.content), equal_to({'name': 'dummy'}))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,1 @@
+# A dummy settings file to make tests that rely on Django run

--- a/tests/unit_tests/django_adapter/test_action_resolver.py
+++ b/tests/unit_tests/django_adapter/test_action_resolver.py
@@ -3,10 +3,24 @@ import unittest
 from hamcrest import assert_that, equal_to
 from mock import MagicMock
 
+from rip.api_schema import ApiSchema
+from rip.crud.crud_resource import CrudResource
 from rip.django_adapter import action_resolver
-
+from rip.view.view_resource import ViewResource
 
 __all__ = ["TestActionResolver"]
+
+
+class MockSchema(ApiSchema):
+    class Meta:
+        schema_name = 'mock'
+
+
+class MockResource(CrudResource):
+    schema_cls = MockSchema()
+
+class MockViewResource(ViewResource):
+    schema_cls = MockSchema()
 
 
 class TestActionResolver(unittest.TestCase):
@@ -14,7 +28,7 @@ class TestActionResolver(unittest.TestCase):
         mock_http_request = MagicMock()
         mock_http_request.method = 'PATCH'
         mock_api = MagicMock()
-        mock_resource = MagicMock()
+        mock_resource = MockResource()
         mock_api.resolve_resource.return_value = mock_resource
         mock_resource.update_detail = expected_action = MagicMock()
 
@@ -26,7 +40,7 @@ class TestActionResolver(unittest.TestCase):
         mock_http_request = MagicMock()
         mock_http_request.method = 'PUT'
         mock_api = MagicMock()
-        mock_resource = MagicMock()
+        mock_resource = MockResource()
         mock_api.resolve_resource.return_value = mock_resource
         mock_resource.create_or_update_detail = expected_action = MagicMock()
 
@@ -38,7 +52,7 @@ class TestActionResolver(unittest.TestCase):
         mock_http_request = MagicMock()
         mock_http_request.method = 'DELETE'
         mock_api = MagicMock()
-        mock_resource = MagicMock()
+        mock_resource = MockResource()
         mock_api.resolve_resource.return_value = mock_resource
         mock_resource.delete_detail = expected_delete_action = MagicMock()
 
@@ -50,7 +64,7 @@ class TestActionResolver(unittest.TestCase):
         mock_http_request = MagicMock()
         mock_http_request.method = 'POST'
         mock_api = MagicMock()
-        mock_resource = MagicMock()
+        mock_resource = MockResource()
         mock_api.resolve_resource.return_value = mock_resource
         mock_resource.create_detail = expected_create_action = MagicMock()
 
@@ -100,3 +114,15 @@ class TestActionResolver(unittest.TestCase):
         action = action_resolver.resolve_action(mock_http_request, api=mock_api,
                                                 url='foo')
         assert_that(action, equal_to(None))
+
+    def test_resolve_view_action(self):
+        mock_http_request = MagicMock()
+        mock_http_request.method = 'GET'
+        mock_api = MagicMock()
+        mock_resource = MockViewResource()
+        mock_api.resolve_resource.return_value = mock_resource
+        mock_resource.read = expected_read_action = MagicMock()
+
+        action = action_resolver.resolve_action(mock_http_request, api=mock_api,
+                                                url='foo')
+        assert_that(action, equal_to(expected_read_action))


### PR DESCRIPTION
Fixes https://github.com/Aplopio/rip/issues/32

You can now add a resource at an arbitrary url without CRUD semantics. 

```python
class TweetViewResource(ViewResource):
    schema_cls = TweetSchema
    view_actions_cls = TweetViewActions
    authorization_cls = TweetViewAuthorization
    authentication_cls = TweetAuthentication

class TweetViewActions(DefaultViewActions):
    def view(self, request):
        return { 'text': 'Hello World' }

api = Api(name='api', version='v1')
api.register_resource('tweet_view', TweetViewResource())
```
##### Coming soon
* Declarative filters on ViewResource