### PR TITLE
Support Filters on view resource

### DIFF
--- a/rip/default_view_actions.py
+++ b/rip/default_view_actions.py
@@ -1,8 +1,11 @@
 class DefaultViewActions(object):
+    request_filters_property = 'request_filters'
+
     def read(self, request):
-        view_data = self.view(request)
+        request_filters = request.context_params.get(self.request_filters_property, {})
+        view_data = self.view(request, **request_filters)
         request.context_params['entity'] = view_data
         return request
 
-    def view(self, request):
-        raise NotImplementedError('You need to override get on actions')
+    def view(self, request, **filters):
+        raise NotImplementedError('You need to override the view method on actions')

--- a/rip/generic_steps/default_data_cleaner.py
+++ b/rip/generic_steps/default_data_cleaner.py
@@ -73,7 +73,7 @@ class DefaultRequestCleaner(object):
             request_filters['aggregate_by'] = \
                 [self._get_attribute_name(field_name)
                  for field_name in aggregate_by]
-            
+
         return request_filters
 
     def clean_data_for_read_detail(self, request):
@@ -116,6 +116,11 @@ class DefaultRequestCleaner(object):
         request.context_params['data'] = self.clean(request,
                                                     data)
         request = self.clean_data_for_read_detail(request)
+        return request
+
+    def clean_data_for_view_read(self, request):
+        request_filters = self.clean_request_params(request)
+        request.context_params['request_filters'] = request_filters
         return request
 
     def clean(self, request, data):

--- a/rip/view/view_pipeline_factory.py
+++ b/rip/view/view_pipeline_factory.py
@@ -6,6 +6,7 @@ def read_pipeline(configuration):
     view_actions = configuration['view_actions']
     authentication = configuration['authentication']
     authorization = configuration['authorization']
+    data_cleaner = configuration['data_cleaner']
     serializer = configuration['serializer']
     post_action_hooks = configuration['post_action_hooks']
     response_converter = configuration['response_converter']
@@ -15,6 +16,7 @@ def read_pipeline(configuration):
         pipeline=[
             authentication.authenticate,
             authorization.authorize_read,
+            data_cleaner.clean_data_for_view_read,
             view_actions.read,
             serializer.serialize_detail,
             post_action_hooks.read_detail_hook,

--- a/rip/view/view_resource.py
+++ b/rip/view/view_resource.py
@@ -1,6 +1,7 @@
 from rip.default_view_actions import DefaultViewActions
 from rip.generic_steps.default_authentication import \
     DefaultAuthentication
+from rip.generic_steps.default_data_cleaner import DefaultRequestCleaner
 from rip.generic_steps.default_post_action_hooks import \
     DefaultPostActionHooks
 from rip.generic_steps.default_response_converter import \
@@ -55,6 +56,7 @@ class ViewResource(object):
     post_action_hooks_cls = DefaultPostActionHooks
     response_converter_cls = DefaultResponseConverter
     serializer_cls = DefaultEntitySerializer
+    data_cleaner_cls = DefaultRequestCleaner
 
     def _setup_configuration(self):
         """
@@ -76,6 +78,7 @@ class ViewResource(object):
         response_converter = self.response_converter_cls(
             schema_cls=self.schema_cls)
         serializer = self.serializer_cls(schema_cls=self.schema_cls)
+        data_cleaner = self.data_cleaner_cls(schema_cls=self.schema_cls)
 
         self.configuration.update(dict(
             authentication=authentication,
@@ -84,6 +87,7 @@ class ViewResource(object):
             view_actions=view_actions,
             post_action_hooks=post_action_hooks,
             response_converter=response_converter,
+            data_cleaner=data_cleaner,
             serializer=serializer))
 
     def __new__(cls, *args, **kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,22 @@
+def patch_class_field(cls, field_name, value):
+    """
+    Patches a field on a class with the value
+    unpatches it when the method exits
+    :param cls:
+    :param field_name:
+    :param value:
+    :return:
+    """
+
+    def outer_wrapper(func):
+        def wrapper(*args, **kwargs):
+            old_field_value = getattr(cls, field_name)
+            setattr(cls, field_name, value)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                setattr(cls, field_name, old_field_value)
+
+        return wrapper
+
+    return outer_wrapper


### PR DESCRIPTION
You can now declare filters on a View and they will get passed on to the ViewActions as kwargs.
This completely implements #32
```python
class TweetViewResource(ViewResource):
    schema_cls = TweetSchema
    view_actions_cls = TweetViewActions
    authorization_cls = TweetViewAuthorization
    authentication_cls = TweetAuthentication
    filter_by_fields = { 'text': (rip.filter_operators.EQUALS,)}

class TweetViewActions(DefaultViewActions):
    def view(self, request, **kwargs):
        return { 'text': kwargs['text'] }

api = Api(name='api', version='v1')
api.register_resource('tweet_view', TweetViewResource())
```