### PR TITLE
List schema fields validation

### DIFF
--- a/rip/generic_steps/default_schema_validation.py
+++ b/rip/generic_steps/default_schema_validation.py
@@ -27,6 +27,10 @@ class DefaultSchemaValidation(object):
     def validate_data(self, request, data):
         errors = {}
         fields_to_validate = self._get_fields_to_validate_data(request, data)
+
+        if data is not None and type(data) != dict:
+            return "This item should be an object."
+
         for field_name, field in fields_to_validate.items():
             validation_result = field.validate(
                 request,

--- a/rip/schema/list_field.py
+++ b/rip/schema/list_field.py
@@ -30,6 +30,10 @@ class ListField(BaseField):
         if self.nullable and value is None:
             return ValidationResult(is_success=True)
 
+        if type(value) != list:
+            return ValidationResult(is_success=False,
+                                    reason="This field should be an array.")
+
         for item in value:
             validation_result = self.field.validate(request, item)
             if not validation_result.is_success:

--- a/tests/unit_tests/generic_steps/test_default_schema_validation.py
+++ b/tests/unit_tests/generic_steps/test_default_schema_validation.py
@@ -92,6 +92,17 @@ class TestSchemaFullValidation(unittest.TestCase):
         assert_that(len(response.data), equal_to(2))
         assert_that(response.data, has_items('name', 'country'))
 
+    def test_input_data_is_not_a_dict(self):
+        data = 'stupid random data'
+        request = request_factory.get_request(
+            data=data,
+            context_params={'crud_action': CrudActions.UPDATE_DETAIL})
+
+        response = self.validation.validate_request_data(request)
+
+        assert_that(response.is_success, equal_to(False))
+        assert_that(response.reason, equal_to(error_types.InvalidData))
+
 
     def test_validate_schema_fields(self):
         pass

--- a/tests/unit_tests/schema/test_list_field.py
+++ b/tests/unit_tests/schema/test_list_field.py
@@ -18,6 +18,13 @@ class TestValidateListField(unittest.TestCase):
 
         assert not result.is_success
 
+    def test_return_failure_if_value_is_not_a_list(self):
+        field = ListField(field=StringField(), nullable=False)
+
+        result = field.validate(request=None, value='blah')
+
+        assert not result.is_success
+
     def test_return_success_if_validation_passes(self):
 
         field = ListField(field=StringField(), nullable=True)


### PR DESCRIPTION
Fix for the issue https://github.com/Aplopio/rip/issues/42

Validates whether the data passed to a list field is actually a list.
For list of schema objects, validates whether the items in the list are actually a dictionary object, rather than a list of primitive types.
