### PR TITLE
added ability to handle ActionForbidden response from entity hooks 

### DIFF
--- a/http_adapter/django_crud_resource.py
+++ b/http_adapter/django_crud_resource.py
@@ -4,7 +4,7 @@ from http_adapter.default_http_response_builder import \
 from http_adapter.default_rip_action_resolver import DefaultRipActionResolver
 from http_adapter.default_rip_request_builder import DefaultRipRequestBuilder
 from model_adapter.model_data_manager import ModelDataManager
-from rip.crud.crud_resource import CrudResource
+from rip.crud.crud_resource import CrudResource, CustomDataMixin
 from rip.generic_steps import error_types
 from rip.response import Response
 from rip.schema_fields.field_types import FieldTypes
@@ -70,3 +70,7 @@ class DjangoModelResource(DjangoResource):
     def get_data_manager(self):
         return self._meta.data_manager_cls(
             resource=self)
+
+
+class CustomDataResource(DjangoResource, CustomDataMixin):
+    pass

--- a/http_adapter/django_crud_resource.py
+++ b/http_adapter/django_crud_resource.py
@@ -3,6 +3,7 @@ from http_adapter.default_http_response_builder import \
     DefaultHttpResponseBuilder
 from http_adapter.default_rip_action_resolver import DefaultRipActionResolver
 from http_adapter.default_rip_request_builder import DefaultRipRequestBuilder
+from model_adapter.crud_repo import ModelRepo
 from model_adapter.model_data_manager import ModelDataManager
 from rip.crud.crud_resource import CrudResource, CustomDataMixin
 from rip.generic_steps import error_types
@@ -60,6 +61,10 @@ class DjangoResource(View, CrudResource):
         return http_response_builder.build_http_response()
 
 
+class CustomDataResource(DjangoResource, CustomDataMixin):
+    pass
+
+
 class DjangoModelResource(DjangoResource):
     id = IntegerField(field_type=FieldTypes.IMMUTABLE, nullable=False)
 
@@ -72,5 +77,46 @@ class DjangoModelResource(DjangoResource):
             resource=self)
 
 
-class CustomDataResource(DjangoResource, CustomDataMixin):
-    pass
+class DjangoModelResource2(DjangoResource, CustomDataMixin):
+    """
+    Provides the same functionality as DjangoModelResource but it does so by
+    overriding the data hooks on the class it self instead of
+    defining a new DataManager.
+    This makes it easy to override the behavior of the data hooks to
+    enable fetching additional data or do additional permission checks
+    after data is fetched or before updating / deleting data.
+
+    Ex: Return error_types.ActionForbidden to return a Forbidden response
+    from any of the entity hooks.
+
+    """
+    id = IntegerField(field_type=FieldTypes.IMMUTABLE, nullable=False)
+
+    class Meta:
+        model_cls = None
+
+    def __init__(self, model_repo_cls=ModelRepo):
+        super(DjangoModelResource2,self). __init__()
+        self.model_repo_cls = model_repo_cls
+        self.model_repo = model_repo_cls(model_cls=self._meta.model_cls)
+
+    def get_entity(self, request, **request_filters):
+        return self.model_repo.get_object(**request_filters)
+
+    def get_entity_list(self, request, limit, offset, **kwargs):
+        return self.model_repo.get_list(offset=offset, limit=limit, **kwargs)
+
+    def get_aggregates(self, request, **request_filters):
+        return self.model_repo.aggregates(**request_filters)
+
+    def update_entity(self, request, entity, **update_params):
+        return self.model_repo.update(entity, **update_params)
+
+    def create_entity(self, request, **data):
+        return self.model_repo.create(**data)
+
+    def delete_entity(self, entity):
+        return self.model_repo.delete(entity)
+
+    def get_total_count(self, request, **kwargs):
+        return self.model_repo.get_count(**kwargs)

--- a/rip/crud/crud_resource.py
+++ b/rip/crud/crud_resource.py
@@ -226,3 +226,36 @@ class CrudResource(ResourceSchemaMixin):
 
         return PipelineComposer(
             name=CrudActions.GET_AGGREGATES, pipeline=aggregates_pipeline)
+
+
+class CustomDataMixin(object):
+    """
+    Provides hooks to manage CRUD operations for Custom data.
+
+    If a user does not have access to the data they requested for,
+    you can return error_types.ActionForbidden from these data hooks.
+
+    Similarly if the object the user has requested for is not found,
+    you can return error_types.ObjectNotFound
+    """
+
+    def get_aggregates(self, request, **request_filters):
+        raise NotImplementedError
+
+    def get_entity(self, request, **request_filters):
+        raise NotImplementedError
+
+    def update_entity(self, request, entity, **update_params):
+        raise NotImplementedError
+
+    def create_entity(self, request, entity, **data):
+        raise NotImplementedError
+
+    def get_entity_list(self, request, limit, offset, **kwargs):
+        raise NotImplementedError
+
+    def get_total_count(self, request, **kwargs):
+        raise NotImplementedError
+
+    def delete_entity(self, entity):
+        raise NotImplementedError

--- a/rip/crud/crud_resource.py
+++ b/rip/crud/crud_resource.py
@@ -248,7 +248,7 @@ class CustomDataMixin(object):
     def update_entity(self, request, entity, **update_params):
         raise NotImplementedError
 
-    def create_entity(self, request, entity, **data):
+    def create_entity(self, request, **data):
         raise NotImplementedError
 
     def get_entity_list(self, request, limit, offset, **kwargs):

--- a/rip/crud/pipeline_composer.py
+++ b/rip/crud/pipeline_composer.py
@@ -20,7 +20,7 @@ class PipelineComposer(object):
 
         for counter, handler in enumerate(pipeline):
             response = handler(request=request)
-            assert type(response) in [Request, Response], \
+            assert isinstance(response, (Request, Response)), \
                 "handle_request of {handler_name} handler did not return a request or a response object".format(
                     handler_name=str(handler))
             if isinstance(response, Response):

--- a/rip/response.py
+++ b/rip/response.py
@@ -1,3 +1,6 @@
+from rip.generic_steps import error_types
+
+
 class Response(object):
     def __init__(self, is_success=True, reason=None, data=None):
         """
@@ -11,3 +14,15 @@ class Response(object):
         self.is_success = is_success
         self.reason = reason
         self.data = data
+
+
+class NotFoundResponse(Response):
+    def __init__(self, data=None):
+        super(NotFoundResponse, self).__init__(
+            is_success=False, reason=error_types.ObjectNotFound, data=data)
+
+
+class ActionForbiddenResponse(Response):
+    def __init__(self, data=None):
+        super(ActionForbiddenResponse, self).__init__(
+            is_success=False, reason=error_types.ActionForbidden, data=data)

--- a/rip/tests/unit_tests/generic_steps/test_default_data_manager.py
+++ b/rip/tests/unit_tests/generic_steps/test_default_data_manager.py
@@ -2,6 +2,7 @@ import unittest
 
 from mock import MagicMock
 
+from rip.generic_steps import error_types
 from rip.generic_steps.default_data_manager import \
     DefaultDataManager
 from rip.generic_steps.error_types import ObjectNotFound, \
@@ -75,7 +76,6 @@ class TestEntityActionsGetEntity(unittest.TestCase):
 
         self.assertEqual(entity, expected_objs[0])
 
-
     def test_should_return_none(self):
         data_manager = DefaultDataManager(MagicMock())
         data_manager.get_entity_list = MagicMock()
@@ -83,7 +83,7 @@ class TestEntityActionsGetEntity(unittest.TestCase):
 
         entity = data_manager.get_entity(request=None)
 
-        self.assertEqual(entity, None)
+        self.assertEqual(entity, error_types.ObjectNotFound)
 
 
 class TestEntityActionsReadList(unittest.TestCase):

--- a/tests/integration_tests/test_read_detail.py
+++ b/tests/integration_tests/test_read_detail.py
@@ -43,7 +43,7 @@ class GetCrudResourceIntegrationTest(PersonResourceBaseTestCase):
 
         assert response.is_success
         data_manager.get_entity_list.assert_called_once_with(
-            request, name='bar', limit=1, offset=0)
+            request, name='bar', limit=2, offset=0)
 
     def test_should_get_none_for_nullable_schema_field(self):
         resource = PersonResource()


### PR DESCRIPTION
(get_entity, update_entity etc.) in default data manager

This is particularly useful for the experience of developers trying to check permissions on data being requested by users. Simply returning
 error_types.ActionForbidden from (get_entity / update_entity) on the resource will return an ActionForbidden Response